### PR TITLE
related fields were not computed on record creation

### DIFF
--- a/mrp_schedule_state/mrp.py
+++ b/mrp_schedule_state/mrp.py
@@ -107,6 +107,11 @@ class MrpProductionWorkcenterLine(orm.Model):
             help="'sub state' of MO state 'Ready To Produce' dedicated to "
                  "planification, scheduling and ordering",
             store={
+                'mrp.production.workcenter.line': [
+                    lambda self, cr, uid, ids, ctx=None: ids,
+                    ['production_id'],
+                    10,
+                ],
                 'mrp.production': [
                     _get_operation_from_production,
                     ['schedule_state'],
@@ -120,6 +125,11 @@ class MrpProductionWorkcenterLine(orm.Model):
             string='Planned MO',
             readonly=True,
             store={
+                'mrp.production.workcenter.line': [
+                    lambda self, cr, uid, ids, ctx=None: ids,
+                    ['production_id'],
+                    10,
+                ],
                 'mrp.production': [
                     _get_operation_from_production,
                     ['date_planned'],


### PR DESCRIPTION
These 2 related fields are not computed when a workcenter.line is created.

@bealdav @sebastienbeau is it ok for you?

I'd like to merge it quickly
Thanks!
