### PR TITLE
allow to schedule workorders from tree menu

### DIFF
--- a/mrp_load_by_schedule_state/__init__.py
+++ b/mrp_load_by_schedule_state/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
-import workc
+from . import workc
+from . import transient

--- a/mrp_load_by_schedule_state/__openerp__.py
+++ b/mrp_load_by_schedule_state/__openerp__.py
@@ -92,6 +92,7 @@ To contribute to this module, please visit http://odoo-community.org.
     'data': [
         'workcenter_view.xml',
         'security/ir.model.access.csv',
+        'transient/order_workorders.xml'
     ],
     'demo': [
     ],

--- a/mrp_load_by_schedule_state/transient/__init__.py
+++ b/mrp_load_by_schedule_state/transient/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#  licence AGPL version 3 or later
+#  see license in __openerp__.py or http://www.gnu.org/licenses/agpl-3.0.txt
+#  Copyright (C) 2015 Akretion (http://www.akretion.com).
+#  @author David BEAL <david.beal@akretion.com>
+#
+##############################################################################
+
+from . import order_workorders

--- a/mrp_load_by_schedule_state/transient/order_workorders.py
+++ b/mrp_load_by_schedule_state/transient/order_workorders.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#  license AGPL version 3 or later
+#  see license in __openerp__.py or http://www.gnu.org/licenses/agpl-3.0.txt
+#  Copyright (C) 2015 Akretion (http://www.akretion.com).
+#  @author Florian da Costa <florian.dacosta@akretion.com>
+#
+##############################################################################
+
+from openerp.osv import orm
+
+
+class OrderWorkorder(orm.TransientModel):
+    _name = 'order.workorder'
+
+    def order_workorders(self, cr, uid, ids, context=None):
+        MrpWorkcenter = self.pool['mrp.workcenter']
+        active_ids = context.get('active_ids', [])
+        MrpWorkcenter.button_order_workorder(
+            cr, uid, active_ids, context=context)
+        return True

--- a/mrp_load_by_schedule_state/transient/order_workorders.xml
+++ b/mrp_load_by_schedule_state/transient/order_workorders.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<openerp>
+  <data>
+
+<record id="view_wiz_order_workorder" model="ir.ui.view">
+    <field name="model">order.workorder</field>
+    <field name="arch" type="xml">
+        <form string="Order Work Orders" version="7.0">
+            <footer>
+                <button name="order_workorders" string="Apply"
+                    type="object" class="oe_highlight"/>
+                or
+                <button special="cancel" string="Cancel" class="oe_link"/>
+            </footer>
+        </form>
+    </field>
+</record>
+
+<act_window
+    id="action_order_workorder"
+    name="Order Work Orders"
+    view_mode="form"
+    target="new"
+    key2="client_action_multi"
+    src_model="mrp.workcenter"
+    res_model="order.workorder"/>
+
+  </data>
+</openerp>

--- a/mrp_load_by_schedule_state/workc.py
+++ b/mrp_load_by_schedule_state/workc.py
@@ -43,6 +43,7 @@ class MrpWorkcenterOrderingKey(orm.Model):
             'Fields')
     }
 
+
 class MrpWorkcenterOrderingField(orm.Model):
     _name = 'mrp.workcenter.ordering.field'
     _description = "Workcenter Ordering Field"


### PR DESCRIPTION
It allows to schedule work orders from the load menu for every workcenter at once and not one by one.

@bealdav @sebastienbeau any comments?

I will merge it Tuesday if nobody is against!
